### PR TITLE
remove dependency on chrono module

### DIFF
--- a/VL53L0X.py
+++ b/VL53L0X.py
@@ -636,11 +636,10 @@ class VL53L0X:
         return True
 
     def perform_single_ref_calibration(self, vhv_init_byte):
-        chrono = Timer.Chrono()
         self._register(SYSRANGE_START, 0x01|vhv_init_byte)
-        chrono.start()
+        startTime = utime.ticks_ms()
         while self._register((RESULT_INTERRUPT_STATUS & 0x07) == 0):
-            time_elapsed = chrono.read_ms()
+            time_elapsed = utime.ticks_diff(utime.ticks_ms(), startTime)
             if time_elapsed > _IO_TIMEOUT:
                 return False
         self._register(SYSTEM_INTERRUPT_CLEAR, 0x01)


### PR DESCRIPTION
I removed the dependency on chrono module to make the library works on reference micropython for esp32. I tested it succesfully with the m5stack vl53l0x module and esp32-wroom-32 with esp32-idf3-20210202-v1.14 micropython firmware.